### PR TITLE
chore: remove proxy from client package

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -15,6 +15,5 @@
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",
     "vite": "^4.4.0"
-  },
-  "proxy": "http://localhost:3001"
+  }
 }


### PR DESCRIPTION
## Summary
- remove obsolete proxy field from client package.json

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689520b019cc8326a8a103d10d354265