### PR TITLE
Add placeholder test scripts and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,14 @@ cp server/.env.example server/.env
 cd server && npm install && npm start &
 cd ../client && npm install && npm run dev
 ```
+
+## Running tests
+
+Both the server and client include placeholder test scripts. From the project root run:
+
+```bash
+cd server && npm test
+cd ../client && npm test
+```
+
+These commands currently print "No tests" and exit with an error code until real tests are added.

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "echo \"No tests\" && exit 1"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,8 @@
   "description": "Express backend for generating business model analyses with OpenAI",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "test": "echo \"No tests\" && exit 1"
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary
- add failing placeholder test scripts to server and client package.json
- document running tests in README

## Testing
- `cd server && npm test | grep -v '^$'`
- `cd client && npm test | grep -v '^$'`


------
https://chatgpt.com/codex/tasks/task_e_689520b631a88326b8c23c00e2adb610